### PR TITLE
Update CustomScaleFix for version 1.10.984

### DIFF
--- a/CustomScaleFix/Configs.h
+++ b/CustomScaleFix/Configs.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <stdint.h>
+#include <string>
+
 namespace Configs {
 	bool GetConfigValue(const char* section, const char* key, bool* dataOut);
 	bool GetConfigValue(const char* section, const char* key, std::uint32_t* dataOut);

--- a/CustomScaleFix/CustomScaleFix.vcxproj
+++ b/CustomScaleFix/CustomScaleFix.vcxproj
@@ -41,15 +41,15 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -116,12 +116,16 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>XBYAK_NO_OP_NAMES;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\..;$(SolutionDir)\..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>common/IPrefix.h</ForcedIncludeFiles>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -133,7 +137,7 @@
       </SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL</PreprocessorDefinitions>
       <ConformanceMode>Default</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\..;$(SolutionDir)\..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <PrecompiledHeader />
@@ -157,14 +161,6 @@
     <None Include="exports.def" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\f4se\f4se.vcxproj">
-      <Project>{a236f69d-8ff9-4491-ac5f-45bf49448bbe}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\f4se_common\f4se_common.vcxproj">
-      <Project>{20c6411c-596f-4b85-be4e-8bc91f59d8a6}</Project>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="FurniturePositions.cpp" />
     <ClCompile Include="ZoomData.cpp" />
     <ClCompile Include="Configs.cpp" />
@@ -177,6 +173,17 @@
     <ClInclude Include="Global.h" />
     <ClInclude Include="PlayerAnimEvents.h" />
     <ClInclude Include="Utils.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\common\common\common_vc14.vcxproj">
+      <Project>{472e19ab-def0-42df-819b-18722e8dc822}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\f4se\f4se.vcxproj">
+      <Project>{a236f69d-8ff9-4491-ac5f-45bf49448bbe}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\f4se_common\f4se_common.vcxproj">
+      <Project>{20c6411c-596f-4b85-be4e-8bc91f59d8a6}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/CustomScaleFix/FurniturePositions.cpp
+++ b/CustomScaleFix/FurniturePositions.cpp
@@ -8,7 +8,7 @@
 #include <f4se/GameForms.h>
 #include <f4se/GameObjects.h>
 #include <f4se/GameReferences.h>
-#include <f4se/xbyak/xbyak.h>
+#include <xbyak/xbyak.h>
 #include <f4se_common/BranchTrampoline.h>
 #include <f4se_common/SafeWrite.h>
 
@@ -128,7 +128,7 @@ namespace FurniturePositions {
 			}
 		};
 
-		RelocAddr<std::uintptr_t> target(0xE85836);
+		RelocAddr<std::uintptr_t> target(0x7435F9);
 
 		void* codeBuf = g_localTrampoline.StartAlloc();
 		asm_code code(codeBuf, (std::uintptr_t)GetModifiedFurniturePosition, target.GetUIntPtr());
@@ -177,7 +177,7 @@ namespace FurniturePositions {
 			}
 		};
 
-		RelocAddr<std::uintptr_t> target(0xD79950);
+		RelocAddr<std::uintptr_t> target(0x514E5D);
 
 		void* codeBuf = g_localTrampoline.StartAlloc();
 		asm_code code(codeBuf, (std::uintptr_t)GetModifiedFurniturePosition, target.GetUIntPtr());

--- a/CustomScaleFix/Global.h
+++ b/CustomScaleFix/Global.h
@@ -3,4 +3,4 @@
 #include <f4se_common/f4se_version.h>
 
 #define PLUGIN_NAME	"CustomScaleFix"
-#define PLUGIN_VERSION	MAKE_EXE_VERSION(2, 6, 2)
+#define PLUGIN_VERSION	MAKE_EXE_VERSION(2, 6, 3)

--- a/CustomScaleFix/PlayerAnimEvents.cpp
+++ b/CustomScaleFix/PlayerAnimEvents.cpp
@@ -14,7 +14,7 @@ namespace PlayerAnimEvents {
 	};
 
 	using PlayerAnimationGraphEventHandler_t = EventResult(*)(void*, BSAnimationGraphEvent*, void*);
-	RelocAddr<std::uintptr_t> PlayerAnimationGraphEventHandler_Target(0x2D442D8 + 0x8);
+	RelocAddr<std::uintptr_t> PlayerAnimationGraphEventHandler_Target(0x236A4C8 + 0x8);
 	PlayerAnimationGraphEventHandler_t PlayerAnimationGraphEventHandler;
 
 	EventResult PlayerAnimationGraphEventHandler_Hook(void* arg1, BSAnimationGraphEvent* a_evn, void* a_dispatcher) {

--- a/CustomScaleFix/Utils.cpp
+++ b/CustomScaleFix/Utils.cpp
@@ -8,13 +8,13 @@
 namespace Utils {
 	float GetScale(TESObjectREFR* a_ref) {
 		using func_t = float(*)(TESObjectREFR*);
-		func_t func = RelocAddr<func_t>(0x3F8540);
+		func_t func = RelocAddr<func_t>(0x4AB5F0);
 		return func(a_ref);
 	}
 
 	void SetScale(TESObjectREFR* a_ref, float a_scale) {
 		using func_t = float(*)(TESObjectREFR*, float);
-		func_t func = RelocAddr<func_t>(0x3F85B0);
+		func_t func = RelocAddr<func_t>(0x50FAC0);
 		func(a_ref, a_scale);
 	}
 

--- a/CustomScaleFix/Utils.h
+++ b/CustomScaleFix/Utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 class TESObjectREFR;
 class Actor;
 class TESForm;

--- a/CustomScaleFix/ZoomData.cpp
+++ b/CustomScaleFix/ZoomData.cpp
@@ -3,7 +3,7 @@
 #include <f4se/GameForms.h>
 #include <f4se/GameObjects.h>
 #include <f4se/GameReferences.h>
-#include <f4se/xbyak/xbyak.h>
+#include <xbyak/xbyak.h>
 #include <f4se_common/BranchTrampoline.h>
 
 #include "Utils.h"
@@ -82,7 +82,7 @@ namespace ZoomData {
 			}
 		};
 
-		RelocAddr<std::uintptr_t> target(0x12444E6);
+		RelocAddr<std::uintptr_t> target(0xF9B181);
 
 		void* codeBuf = g_localTrampoline.StartAlloc();
 		asm_code code(codeBuf, (std::uintptr_t)GetZoomData, target.GetUIntPtr());

--- a/CustomScaleFix/exports.def
+++ b/CustomScaleFix/exports.def
@@ -2,3 +2,4 @@ LIBRARY	"CustomScaleFix"
 EXPORTS
 F4SEPlugin_Query
 F4SEPlugin_Load
+F4SEPlugin_Version

--- a/CustomScaleFix/main.cpp
+++ b/CustomScaleFix/main.cpp
@@ -38,7 +38,7 @@ extern "C" {
 		info->name = PLUGIN_NAME;
 		info->version = PLUGIN_VERSION;
 
-		if (f4se->runtimeVersion != RUNTIME_VERSION_1_10_163) {
+		if (f4se->runtimeVersion != RUNTIME_VERSION_1_10_984) {
 			_MESSAGE("[Critical] unsupported runtime version %d", f4se->runtimeVersion);
 			return false;
 		}
@@ -78,14 +78,29 @@ extern "C" {
 		if (bUseCameraOverrideScaleFix)
 			PlayerAnimEvents::Hooks_PlayerAnimEvents();
 
-		if (bUseCustomFurniturePosition) {
+		/*if (bUseCustomFurniturePosition) {
 			FurniturePositions::Hooks_PlayFurnitureAnimation();
 			FurniturePositions::Hooks_InitializeChairBedQuickPosition();
 
 			if (g_messaging)
 				g_messaging->RegisterListener(g_pluginHandle, "F4SE", OnF4SEMessage);
-		}
+		}*/
 
 		return true;
 	}
+
+	F4SEPluginVersionData F4SEPlugin_Version =
+	{
+		F4SEPluginVersionData::kVersion,
+
+		PLUGIN_VERSION,
+		PLUGIN_NAME,
+		"VG",
+
+		0,	// not version independent
+		0,	// not version independent (extended field)
+		{ RUNTIME_VERSION_1_10_984, 0 },	// compatible with 1.10.980
+
+		0,	// works with any version of the script extender. you probably do not need to put anything here
+	};
 };


### PR DESCRIPTION
I've attempted to update the CustomScaleFix mod to 1.10.984. But so far I only have the terminal fix fully working. The ZoomData adjustment causes the weapon to rotate strangely in first person version. I also can't seem to find the right location to inject the trampoline for the furniture position adjustment in the new executable.